### PR TITLE
Refactor shadcn components to utilize field context

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,8 +1,6 @@
 import { useState } from "react"
-import { useForm } from "@tanstack/react-form"
 import {
   Form,
-  FormField,
   FormItem,
   FormLabel,
   FormControl,
@@ -11,12 +9,13 @@ import {
 } from "@/components/ui/form"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
+import { useAppForm } from "./hooks/form-hook"
 import ZodFormExample from "./ZodFormExample"
 
 export default function App() {
   const [showZodForm, setShowZodForm] = useState(false)
 
-  const form = useForm({
+  const form = useAppForm({
     defaultValues: {
       firstName: "",
       lastName: "",
@@ -60,120 +59,114 @@ export default function App() {
         </Button>
       </div>
 
-      <Form
-        form={form}
-        onSubmit={(e) => {
-          e.preventDefault()
-          e.stopPropagation()
-          form.handleSubmit()
-        }}
-        className="space-y-4"
-      >
-        <FormField
-          name="firstName"
-          validators={{
-            onChange: ({ value }: { value: string }) =>
-              !value
-                ? "A first name is required"
-                : value.length < 2
-                  ? "First name must be at least 2 characters"
-                  : undefined,
-          }}
-        >
-          {(field) => (
-            <FormItem>
-              <FormLabel>First Name</FormLabel>
-              <FormControl>
-                <Input
-                  placeholder="Enter your first name"
-                  value={field.state.value}
-                  onBlur={field.handleBlur}
-                  onChange={(e) => field.handleChange(e.target.value)}
-                />
-              </FormControl>
-              <FormDescription>
-                This is your public display first name.
-              </FormDescription>
-              <FormMessage />
-            </FormItem>
-          )}
-        </FormField>
-
-        <FormField
-          name="lastName"
-          validators={{
-            onChange: ({ value }: { value: string }) =>
-              !value
-                ? "A last name is required"
-                : value.length < 2
-                  ? "Last name must be at least 2 characters"
-                  : undefined,
-          }}
-        >
-          {(field) => (
-            <FormItem>
-              <FormLabel>Last Name</FormLabel>
-              <FormControl>
-                <Input
-                  placeholder="Enter your last name"
-                  value={field.state.value}
-                  onBlur={field.handleBlur}
-                  onChange={(e) => field.handleChange(e.target.value)}
-                />
-              </FormControl>
-              <FormDescription>
-                This is your public display last name.
-              </FormDescription>
-              <FormMessage />
-            </FormItem>
-          )}
-        </FormField>
-
-        <FormField name="email">
-          {(field) => (
-            <FormItem>
-              <FormLabel>Email</FormLabel>
-              <FormControl>
-                <Input
-                  type="email"
-                  placeholder="Enter your email"
-                  value={field.state.value}
-                  onChange={(e) => field.handleChange(e.target.value)}
-                  onBlur={field.handleBlur}
-                />
-              </FormControl>
-              <FormDescription>
-                We'll never share your email with anyone else.
-              </FormDescription>
-              <FormMessage />
-            </FormItem>
-          )}
-        </FormField>
-
-        <div className="pt-4">
-          <form.Subscribe
-            selector={(state) => [state.canSubmit, state.isSubmitting]}
+      <form.AppForm>
+        <Form className="space-y-4">
+          <form.AppField
+            name="firstName"
+            validators={{
+              onChange: ({ value }: { value: string }) =>
+                !value
+                  ? "A first name is required"
+                  : value.length < 2
+                    ? "First name must be at least 2 characters"
+                    : undefined,
+            }}
           >
-            {([canSubmit, isSubmitting]) => (
-              <div className="flex gap-2">
-                <Button type="submit" disabled={!canSubmit}>
-                  {isSubmitting ? "Submitting..." : "Submit"}
-                </Button>
-                <Button
-                  type="button"
-                  variant="outline"
-                  onClick={(e) => {
-                    e.preventDefault()
-                    form.reset()
-                  }}
-                >
-                  Reset
-                </Button>
-              </div>
+            {(field) => (
+              <FormItem>
+                <FormLabel>First Name</FormLabel>
+                <FormControl>
+                  <Input
+                    placeholder="Enter your first name"
+                    value={field.state.value}
+                    onBlur={field.handleBlur}
+                    onChange={(e) => field.handleChange(e.target.value)}
+                  />
+                </FormControl>
+                <FormDescription>
+                  This is your public display first name.
+                </FormDescription>
+                <FormMessage />
+              </FormItem>
             )}
-          </form.Subscribe>
-        </div>
-      </Form>
+          </form.AppField>
+
+          <form.AppField
+            name="lastName"
+            validators={{
+              onChange: ({ value }: { value: string }) =>
+                !value
+                  ? "A last name is required"
+                  : value.length < 2
+                    ? "Last name must be at least 2 characters"
+                    : undefined,
+            }}
+          >
+            {(field) => (
+              <FormItem>
+                <FormLabel>Last Name</FormLabel>
+                <FormControl>
+                  <Input
+                    placeholder="Enter your last name"
+                    value={field.state.value}
+                    onBlur={field.handleBlur}
+                    onChange={(e) => field.handleChange(e.target.value)}
+                  />
+                </FormControl>
+                <FormDescription>
+                  This is your public display last name.
+                </FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          </form.AppField>
+
+          <form.AppField name="email">
+            {(field) => (
+              <FormItem>
+                <FormLabel>Email</FormLabel>
+                <FormControl>
+                  <Input
+                    type="email"
+                    placeholder="Enter your email"
+                    value={field.state.value}
+                    onChange={(e) => field.handleChange(e.target.value)}
+                    onBlur={field.handleBlur}
+                  />
+                </FormControl>
+                <FormDescription>
+                  We'll never share your email with anyone else.
+                </FormDescription>
+                <FormMessage />
+              </FormItem>
+            )}
+          </form.AppField>
+
+          <div className="pt-4">
+            <form.Subscribe
+              selector={(state) => [state.canSubmit, state.isSubmitting]}
+            >
+              {([canSubmit, isSubmitting]) => (
+                <div className="flex gap-2">
+                  <Button type="submit" disabled={!canSubmit}>
+                    {isSubmitting ? "Submitting..." : "Submit"}
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={(e) => {
+                      e.preventDefault()
+                      form.reset()
+                    }}
+                  >
+                    Reset
+                  </Button>
+                </div>
+              )}
+            </form.Subscribe>
+          </div>
+        </Form>
+      </form.AppForm>
     </div>
   )
 }

--- a/src/ZodFormExample.tsx
+++ b/src/ZodFormExample.tsx
@@ -1,8 +1,6 @@
-import { useForm } from "@tanstack/react-form"
 import { z } from "zod"
 import {
   Form,
-  FormField,
   FormItem,
   FormLabel,
   FormControl,
@@ -13,6 +11,7 @@ import { Button } from "@/components/ui/button"
 import { Input } from "./components/ui/input"
 import { Checkbox } from "./components/ui/checkbox"
 import { Textarea } from "./components/ui/textarea"
+import { useAppForm } from "./hooks/form-hook"
 
 // Define Zod schema
 const userSchema = z.object({
@@ -36,19 +35,21 @@ const userSchema = z.object({
     .refine((val) => val === true, "You must accept the terms and conditions"),
 })
 
-type UserFormData = z.infer<typeof userSchema>
+type UserFormData = z.input<typeof userSchema>
 
 export default function ZodFormExample() {
-  const form = useForm({
-    defaultValues: {
-      firstName: "",
-      lastName: "",
-      email: "",
-      age: 18,
-      website: "",
-      bio: "",
-      terms: false,
-    } as UserFormData,
+  const defaultValues: UserFormData = {
+    firstName: "",
+    lastName: "",
+    email: "",
+    age: 18,
+    website: "",
+    bio: "",
+    terms: false,
+  }
+
+  const form = useAppForm({
+    defaultValues,
     validators: {
       onChange: userSchema,
     },
@@ -67,197 +68,200 @@ export default function ZodFormExample() {
         </p>
       </div>
 
-      <Form
-        form={form}
-        onSubmit={(e) => {
-          e.preventDefault()
-          e.stopPropagation()
-          form.handleSubmit()
-        }}
-        className="space-y-6"
-      >
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <FormField name="firstName">
+      <form.AppForm>
+        <Form className="space-y-6">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <form.AppField name="firstName">
+              {(field) => (
+                <FormItem>
+                  <FormLabel>First Name *</FormLabel>
+                  <FormControl>
+                    <Input
+                      placeholder="Enter your first name"
+                      value={field.state.value}
+                      onChange={(e) => field.handleChange(e.target.value)}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            </form.AppField>
+
+            <form.AppField name="lastName">
+              {(field) => (
+                <FormItem>
+                  <FormLabel>Last Name *</FormLabel>
+                  <FormControl>
+                    <Input
+                      placeholder="Enter your last name"
+                      value={field.state.value}
+                      onChange={(e) => field.handleChange(e.target.value)}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            </form.AppField>
+          </div>
+
+          <form.AppField name="email">
             {(field) => (
               <FormItem>
-                <FormLabel>First Name *</FormLabel>
+                <FormLabel>Email Address *</FormLabel>
                 <FormControl>
                   <Input
-                    placeholder="Enter your first name"
-                    value={field.state.value}
-                    onChange={(e) => field.handleChange(e.target.value)}
-                  />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          </FormField>
-
-          <FormField name="lastName">
-            {(field) => (
-              <FormItem>
-                <FormLabel>Last Name *</FormLabel>
-                <FormControl>
-                  <Input
-                    placeholder="Enter your last name"
-                    value={field.state.value}
-                    onChange={(e) => field.handleChange(e.target.value)}
-                  />
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          </FormField>
-        </div>
-
-        <FormField name="email">
-          {(field) => (
-            <FormItem>
-              <FormLabel>Email Address *</FormLabel>
-              <FormControl>
-                <Input
-                  type="email"
-                  placeholder="Enter your email address"
-                  value={field.state.value}
-                  onChange={(e) => field.handleChange(e.target.value)}
-                />
-              </FormControl>
-              <FormDescription>
-                We'll never share your email with anyone else.
-              </FormDescription>
-              <FormMessage />
-            </FormItem>
-          )}
-        </FormField>
-
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <FormField name="age">
-            {(field) => (
-              <FormItem>
-                <FormLabel>Age *</FormLabel>
-                <FormControl>
-                  <Input
-                    type="number"
-                    placeholder="Enter your age"
-                    value={field.state.value}
-                    onChange={(e) => field.handleChange(Number(e.target.value))}
-                  />
-                </FormControl>
-                <FormDescription>
-                  Must be 18 or older to register.
-                </FormDescription>
-                <FormMessage />
-              </FormItem>
-            )}
-          </FormField>
-
-          <FormField name="website">
-            {(field) => (
-              <FormItem>
-                <FormLabel>Website (Optional)</FormLabel>
-                <FormControl>
-                  <Input
-                    type="url"
-                    placeholder="https://your-website.com"
+                    type="email"
+                    placeholder="Enter your email address"
                     value={field.state.value}
                     onChange={(e) => field.handleChange(e.target.value)}
                   />
                 </FormControl>
                 <FormDescription>
-                  Your personal or professional website.
+                  We'll never share your email with anyone else.
                 </FormDescription>
                 <FormMessage />
               </FormItem>
             )}
-          </FormField>
-        </div>
+          </form.AppField>
 
-        <FormField name="bio">
-          {(field) => (
-            <FormItem>
-              <FormLabel>Bio (Optional)</FormLabel>
-              <FormControl>
-                <Textarea
-                  placeholder="Tell us about yourself..."
-                  value={field.state.value}
-                  onChange={(e) => field.handleChange(e.target.value)}
-                />
-              </FormControl>
-              <FormDescription>
-                Brief description about yourself (max 500 characters).
-              </FormDescription>
-              <FormMessage />
-            </FormItem>
-          )}
-        </FormField>
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <form.AppField name="age">
+              {(field) => (
+                <FormItem>
+                  <FormLabel>Age *</FormLabel>
+                  <FormControl>
+                    <Input
+                      type="number"
+                      placeholder="Enter your age"
+                      value={field.state.value}
+                      onChange={(e) =>
+                        field.handleChange(Number(e.target.value))
+                      }
+                    />
+                  </FormControl>
+                  <FormDescription>
+                    Must be 18 or older to register.
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            </form.AppField>
 
-        <FormField name="terms">
-          {(field) => (
-            <FormItem className="flex flex-row items-start space-x-3 space-y-0">
-              <FormControl>
-                <Checkbox
-                  checked={field.state.value}
-                  onCheckedChange={(checked) => field.handleChange(checked)}
-                />
-              </FormControl>
-              <div className="space-y-1 leading-none">
-                <FormLabel>Accept terms and conditions *</FormLabel>
+            <form.AppField name="website">
+              {(field) => (
+                <FormItem>
+                  <FormLabel>Website (Optional)</FormLabel>
+                  <FormControl>
+                    <Input
+                      type="url"
+                      placeholder="https://your-website.com"
+                      value={field.state.value}
+                      onChange={(e) => field.handleChange(e.target.value)}
+                    />
+                  </FormControl>
+                  <FormDescription>
+                    Your personal or professional website.
+                  </FormDescription>
+                  <FormMessage />
+                </FormItem>
+              )}
+            </form.AppField>
+          </div>
+
+          <form.AppField name="bio">
+            {(field) => (
+              <FormItem>
+                <FormLabel>Bio (Optional)</FormLabel>
+                <FormControl>
+                  <Textarea
+                    placeholder="Tell us about yourself..."
+                    value={field.state.value}
+                    onChange={(e) => field.handleChange(e.target.value)}
+                  />
+                </FormControl>
                 <FormDescription>
-                  You agree to our Terms of Service and Privacy Policy.
+                  Brief description about yourself (max 500 characters).
                 </FormDescription>
                 <FormMessage />
-              </div>
-            </FormItem>
-          )}
-        </FormField>
+              </FormItem>
+            )}
+          </form.AppField>
 
-        <div className="pt-6 border-t">
-          <form.Subscribe
-            selector={(state) => [state.canSubmit, state.isSubmitting]}
-          >
-            {([canSubmit, isSubmitting]) => (
-              <div className="flex gap-3">
-                <Button type="submit" disabled={!canSubmit} className="flex-1">
-                  {isSubmitting ? "Creating Account..." : "Create Account"}
-                </Button>
-                <Button
-                  type="button"
-                  variant="outline"
-                  onClick={(e) => {
-                    e.preventDefault()
-                    form.reset()
-                  }}
-                >
-                  Reset Form
-                </Button>
-              </div>
+          <form.AppField name="terms">
+            {(field) => (
+              <FormItem className="flex flex-row items-start space-x-3 space-y-0">
+                <FormControl>
+                  <Checkbox
+                    checked={field.state.value}
+                    // 'indeterminate' is coerced to false
+                    onCheckedChange={(checked) =>
+                      field.handleChange(checked === true)
+                    }
+                  />
+                </FormControl>
+                <div className="space-y-1 leading-none">
+                  <FormLabel>Accept terms and conditions *</FormLabel>
+                  <FormDescription>
+                    You agree to our Terms of Service and Privacy Policy.
+                  </FormDescription>
+                  <FormMessage />
+                </div>
+              </FormItem>
+            )}
+          </form.AppField>
+
+          <div className="pt-6 border-t">
+            <form.Subscribe
+              selector={(state) => [state.canSubmit, state.isSubmitting]}
+            >
+              {([canSubmit, isSubmitting]) => (
+                <div className="flex gap-3">
+                  <Button
+                    type="submit"
+                    disabled={!canSubmit}
+                    className="flex-1"
+                  >
+                    {isSubmitting ? "Creating Account..." : "Create Account"}
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={(e) => {
+                      e.preventDefault()
+                      form.reset()
+                    }}
+                  >
+                    Reset Form
+                  </Button>
+                </div>
+              )}
+            </form.Subscribe>
+          </div>
+
+          {/* Form State Debug Info */}
+          <form.Subscribe>
+            {(state) => (
+              <details className="mt-6 p-4 bg-muted rounded-lg">
+                <summary className="cursor-pointer font-medium">
+                  Debug: Form State
+                </summary>
+                <pre className="mt-2 text-xs overflow-auto">
+                  {JSON.stringify(
+                    {
+                      values: state.values,
+                      errors: state.errors,
+                      canSubmit: state.canSubmit,
+                      isSubmitting: state.isSubmitting,
+                    },
+                    null,
+                    2
+                  )}
+                </pre>
+              </details>
             )}
           </form.Subscribe>
-        </div>
-
-        {/* Form State Debug Info */}
-        <form.Subscribe>
-          {(state) => (
-            <details className="mt-6 p-4 bg-muted rounded-lg">
-              <summary className="cursor-pointer font-medium">
-                Debug: Form State
-              </summary>
-              <pre className="mt-2 text-xs overflow-auto">
-                {JSON.stringify(
-                  {
-                    values: state.values,
-                    errors: state.errors,
-                    canSubmit: state.canSubmit,
-                    isSubmitting: state.isSubmitting,
-                  },
-                  null,
-                  2
-                )}
-              </pre>
-            </details>
-          )}
-        </form.Subscribe>
-      </Form>
+        </Form>
+      </form.AppForm>
     </div>
   )
 }

--- a/src/hooks/form-hook.tsx
+++ b/src/hooks/form-hook.tsx
@@ -1,0 +1,9 @@
+import { fieldContext, formContext } from "@/components/ui/form"
+import { createFormHook } from "@tanstack/react-form"
+
+export const { useAppForm, withForm } = createFormHook({
+  fieldContext,
+  formContext,
+  fieldComponents: {},
+  formComponents: {},
+})


### PR DESCRIPTION
As discussed in DMs, this PR refactors the provided shadcn components to utilize field context. It additionally exports the context hooks to allow further customization (such as custom Input elements).

The components do not need to be passed to `fieldComponents` or `formComponents` to be useable, and won't break if a user decides to do so. However, there are some requirements for context:

Context requirements:
* Form components must be used within `<form.AppField>`.
* Form labels, descriptions and messages must be used within a `<FormItem>`

The components will error with the missing component if used outside of them.

Errors are configured to only show if
* A field has been touched
* The user has attempted to submit before

Note that the errors still exist behind the scenes (since form listeners generate them for all fields, including untouched ones). This may impact how `canSubmit` behaves. If that's a concern, subscribe to other form meta properties such as `submissionAttempts` or `isDefaultValue` to get the desired behaviour.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined form handling across the app by introducing a custom form hook and associated components, replacing previous form implementations.
  * Simplified form submission and validation logic for a more consistent user experience.
  * Improved accessibility and error messaging in form fields.
  * Added a debug panel in the Zod form example to display real-time form state.

* **New Features**
  * Introduced a reusable custom form hook for easier form management.
  * Added a debug panel for monitoring form state in real time within the Zod form example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->